### PR TITLE
Change "request" to "response"

### DIFF
--- a/xsdb-demo/index.html
+++ b/xsdb-demo/index.html
@@ -51,7 +51,7 @@
     <code>&lt;img&nbsp;src=&quot;https://www.chromium.org/&quot;&gt;</code>
     element that tries to sneak a cross-origin text/html document into
     memory of a renderer process hosting another origin.</li>
-    <li>Observe that CORB blocks the http request triggered by the inserted
+    <li>Observe that CORB blocks the http response triggered by the inserted
       <code>img</code> element.
       <ul>
         <li>Whenever CORB blocks a reponse there is a DevTools console message:


### PR DESCRIPTION
Found this demo on https://www.chromestatus.com/feature/5629709824032768 while reading up on CORB and was a little confused when it said that CORB blocks the "request". CORB really blocks the browser from reading the response... thought it would be good to clarify.